### PR TITLE
added Windows detection and small typo fixes

### DIFF
--- a/fd-dired.el
+++ b/fd-dired.el
@@ -59,12 +59,12 @@
   :group 'fd-dired)
 
 (defcustom fd-dired-pre-fd-args "-0 -c never"
-  "Fd argumens inserted before user arguments."
+  "Fd arguments inserted before user arguments."
   :type 'string
   :group 'fd-dired)
 
 (defcustom fd-grep-dired-pre-grep-args "--color never --regexp"
-  "Fd grep argumens inserted before user arguments."
+  "Fd grep arguments inserted before user arguments."
   :type 'string
   :group 'fd-dired)
 

--- a/fd-dired.el
+++ b/fd-dired.el
@@ -70,13 +70,13 @@
 
 (defcustom fd-dired-ls-option
   (pcase system-type
-    ('gnu/linux
-     `(,(concat "| xargs -0 " insert-directory-program " -ld --quoting-style=literal | uniq") . "-ld"))
     ('darwin
      ;; NOTE: here `gls' need to `brew install coreutils'
      (if (executable-find "gls")
          `(,(concat "| xargs -0 " "gls -ld --quoting-style=literal | uniq") . "-ld")
-       (warn "macOS system default 'ls' command does not support option --quoting-style=literal.\n Please install with: brew install coreutils"))))
+       (warn "macOS system default 'ls' command does not support option --quoting-style=literal.\n Please install with: brew install coreutils")))
+    (_
+     `(,(concat "| xargs -0 " insert-directory-program " -ld --quoting-style=literal | uniq") . "-ld")))
   "A pair of options to produce and parse an `ls -l'-type list from `fd'.
 This is a cons of two strings (FD-ARGUMENTS . LS-SWITCHES).
 FD-ARGUMENTS is the option passed to `fd' to produce a file


### PR DESCRIPTION
1. fd-dired-ls-option wasn't set on Windows because this was only detecting gnu-linux and darwin systems
    fixes -> #16

2. typo: argumens -> arguments